### PR TITLE
End of Life

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ This tool is part of the [Blitz Framework](http://friendsofepub.github.io/Blitz/
 
 ## Important Note
 
-We’re in the process of sunsetting the entire Blitz Project, which means this repository will reach End of Life and be archived as read-only on July 1, 2020. Don’t worry, all current and future forks will continue to work after this date.
-
-If you are interested in the sunsetting roadmap, or taking over this repository’s maintenance and development, please [check the related meta issue in Blitz](https://github.com/FriendsOfEpub/Blitz/issues/66).
+All the Blitz repositories reached End Of Life on July 1, 2020. The entire project is no longer maintained and its repositories are read-only. You can still fork them if they can be useful to you.
 
 ## Toc
 


### PR DESCRIPTION
This PR sunsets this repo. 

As of July 1st, 2020 the Blitz project is no longer maintained and its repositories become read-only. You can still fork the archived repos though.